### PR TITLE
Freebsd fixes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos C++ library.
 Release 0.4.0 (pending)
 ==========================
 
+- Library fixes to support compilation on FreeBSD systems
 - Use default debug log level for plugin registry events
 - Allow for plugin module re-initialization after deinit()
 - Fixed weak storage of plugin's associated module object

--- a/cmake/PothosStandardFlags.cmake
+++ b/cmake/PothosStandardFlags.cmake
@@ -66,3 +66,7 @@ if(MSVC)
     add_compile_options(/wd4275) #disable non – DLL-interface classkey 'identifier' used as base for DLL-interface classkey 'identifier'
     add_compile_options(/wd4503) #'identifier' : decorated name length exceeded, name was truncated
 endif(MSVC)
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+    add_compile_options(-stdlib=libc++)
+endif()

--- a/lib/Framework/BufferAccumulator.cpp
+++ b/lib/Framework/BufferAccumulator.cpp
@@ -172,7 +172,7 @@ void Pothos::BufferAccumulator::pop(const size_t numBytes)
         if (fOverBounds and f.getEnd() == b.address)
         {
             b.address -= f.length;
-            b.length =+ f.length;
+            b.length += f.length;
             queue.pop_front();
         }
     }

--- a/lib/Framework/SharedBufferUnix.cpp
+++ b/lib/Framework/SharedBufferUnix.cpp
@@ -21,6 +21,10 @@
 #include <numa.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/stat.h>
+#endif
+
 /***********************************************************************
  * aligned allocator for a generic memory slab (uses new/delete)
  **********************************************************************/

--- a/lib/Framework/ThreadConfigUnix.cpp
+++ b/lib/Framework/ThreadConfigUnix.cpp
@@ -15,6 +15,11 @@
 #include <thread>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#endif
+
 std::string ThreadEnvironment::setPriority(const double prio)
 {
     //no negative priorities supported on this OS
@@ -44,8 +49,22 @@ std::string ThreadEnvironment::setCPUAffinity(const std::vector<size_t> &affinit
 {
     #ifdef __APPLE__
     return "sched_setaffinity() not available";
-    #else
+    #elif __FreeBSD__
+    cpuset_t cpuset;
+    CPU_ZERO(&cpuset);
+    for (const auto &cpu : affinity)
+    {
+        CPU_SET(cpu, &cpuset);
+    }
 
+    std::string errorMsg;
+    if (cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(cpuset), &cpuset) == -1)
+    {
+        errorMsg = strerror(errno);
+    }
+
+    return errorMsg;
+    #else
     //create cpu bit set
     cpu_set_t *cpusetp = CPU_ALLOC(Poco::Environment::processorCount());
     if (cpusetp == nullptr) return "CPU_ALLOC";

--- a/lib/Util/FileLockUnix.cpp
+++ b/lib/Util/FileLockUnix.cpp
@@ -10,6 +10,10 @@
 #include <cstring> //strerror
 #include <cerrno> //errno
 
+#ifdef __FreeBSD__
+#include <sys/stat.h>
+#endif
+
 struct Pothos::Util::FileLock::Impl
 {
     Impl(void):


### PR DESCRIPTION
Includes compilation [fixes for freebsd](https://github.com/sghctoma/freebsd-ports/tree/master/comms/pothos/files) from @sghctoma

* specify -stdlib=libc++ with C++11
* added missing system includes
* cpu affinity implementation

Additional fixes may be required to fix unit tests, but this changeset takes care of cross platform compilation issues and does not affect any existing functionality.