### PR TITLE
GCC compiler warnings

### DIFF
--- a/lib/Framework/Builtin/TestBufferConvert.cpp
+++ b/lib/Framework/Builtin/TestBufferConvert.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -15,25 +15,25 @@
 template <typename InType, typename OutType>
 bool checkEqual(const InType in, const OutType out)
 {
-    return in == out;
+    return double(in) == double(out);
 }
 
 template <typename InType, typename OutType>
 bool checkEqual(const InType in, const std::complex<OutType> out)
 {
-    return in == out.real() and InType(0) == out.imag();
+    return checkEqual(in, out.real()) and checkEqual(InType(0), out.imag());
 }
 
 template <typename InType, typename OutType>
 bool checkEqual(const std::complex<InType> in, const std::complex<OutType> out)
 {
-    return in.real() == out.real() and in.imag() == out.imag();
+    return checkEqual(in.real(), out.real()) and checkEqual(in.imag(), out.imag());
 }
 
 template <typename InType, typename OutType>
 bool checkEqual(const std::complex<InType> in, const OutType outRe, const OutType outIm)
 {
-    return in.real() == outRe and in.imag() == outIm;
+    return checkEqual(in.real(), outRe) and checkEqual(in.imag(), outIm);
 }
 
 /***********************************************************************

--- a/lib/Framework/WorkerActorPortAllocation.cpp
+++ b/lib/Framework/WorkerActorPortAllocation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "Framework/WorkerActor.hpp"
@@ -136,7 +136,7 @@ void Pothos::WorkerActor::autoDeletePort(const std::string &name, PortsType &por
     }
 
     //remove it from indexed ports and strip null ports
-    if (port.index() >= 0 and port.index() < indexedPorts.size())
+    if (port.index() >= 0 and size_t(port.index()) < indexedPorts.size())
     {
         indexedPorts[port.index()] = nullptr;
     }

--- a/lib/Object/Builtin/ConvertCommonImpl.hpp
+++ b/lib/Object/Builtin/ConvertCommonImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -8,7 +8,6 @@
 #include <Pothos/Plugin.hpp>
 #include <Pothos/Callable.hpp>
 #include <Poco/Format.h>
-#include <type_traits>
 #include <limits>
 #include <complex>
 #include <string>
@@ -36,22 +35,6 @@ typedef std::complex<float> cfloat;
 typedef std::complex<double> cdouble;
 
 /***********************************************************************
- * make signed that handles floats
- * https://stackoverflow.com/questions/16377736/stdmake-signed-that-accepts-floating-point-types
- **********************************************************************/
-template<typename T, typename Enable = void>
-struct my_make_signed
-{
-    typedef typename std::make_signed<T>::type type;
-};
-
-template<typename T>
-struct my_make_signed<T, typename std::enable_if<std::is_floating_point<T>::value>::type>
-{
-    typedef T type;
-};
-
-/***********************************************************************
  * type conversion checkers
  **********************************************************************/
 
@@ -59,9 +42,8 @@ struct my_make_signed<T, typename std::enable_if<std::is_floating_point<T>::valu
 template <typename OutType, typename InType>
 void convertNumCheck(const InType &in)
 {
-    if (in > std::numeric_limits<OutType>::max() or //too large
-        (std::is_signed<InType>::value and typename my_make_signed<InType>::type(in) <
-        typename my_make_signed<OutType>::type(std::numeric_limits<OutType>::lowest()))) //too small
+    if (double(in) > double(std::numeric_limits<OutType>::max()) or //too large
+        double(in) < double(std::numeric_limits<OutType>::lowest())) //too small
     {
         throw Pothos::RangeException(Poco::format("value %s out of range for output type %s",
             std::to_string(in), Pothos::Util::typeInfoToString(typeid(OutType))));


### PR DESCRIPTION
* Fixed signed compare warnings on templated functions
* gcc flags for python toolkit to get rid of strict aliasing warnings