### PR TITLE
Buffer pool class + OutputPort::getBuffer()

### DIFF
--- a/include/Pothos/Framework.hpp
+++ b/include/Pothos/Framework.hpp
@@ -4,7 +4,7 @@
 /// Top level include wrapper for Framework classes.
 ///
 /// \copyright
-/// Copyright (c) 2014-2014 Josh Blum
+/// Copyright (c) 2014-2016 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -28,6 +28,7 @@
 #include <Pothos/Framework/BlockRegistry.hpp>
 #include <Pothos/Framework/BufferManager.hpp>
 #include <Pothos/Framework/BufferAccumulator.hpp>
+#include <Pothos/Framework/BufferPool.hpp>
 #include <Pothos/Framework/BufferChunk.hpp>
 #include <Pothos/Framework/SharedBuffer.hpp>
 #include <Pothos/Framework/ManagedBuffer.hpp>

--- a/include/Pothos/Framework/BufferAccumulator.hpp
+++ b/include/Pothos/Framework/BufferAccumulator.hpp
@@ -10,9 +10,9 @@
 
 #pragma once
 #include <Pothos/Config.hpp>
+#include <Pothos/Framework/BufferPool.hpp>
 #include <Pothos/Framework/BufferChunk.hpp>
 #include <Pothos/Util/RingDeque.hpp>
-#include <memory>
 #include <cassert>
 
 namespace Pothos {
@@ -34,6 +34,9 @@ public:
 
     //! Create a new buffer accumulator
     BufferAccumulator(void);
+
+    //! Clear the contents of this buffer accumulator
+    void clear(void);
 
     /*!
      * Is the accumulator empty?
@@ -84,8 +87,7 @@ private:
     Util::RingDeque<BufferChunk> _queue;
     size_t _bytesAvailable;
     bool _inPoolBuffer;
-    struct Impl;
-    std::shared_ptr<Impl> _impl;
+    Pothos::BufferPool _pool;
 };
 
 } //namespace Pothos

--- a/include/Pothos/Framework/BufferAccumulator.hpp
+++ b/include/Pothos/Framework/BufferAccumulator.hpp
@@ -4,7 +4,7 @@
 /// BufferAccumulator provides an input pool of buffers.
 ///
 /// \copyright
-/// Copyright (c) 2013-2014 Josh Blum
+/// Copyright (c) 2013-2016 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -83,6 +83,7 @@ public:
 private:
     Util::RingDeque<BufferChunk> _queue;
     size_t _bytesAvailable;
+    bool _inPoolBuffer;
     struct Impl;
     std::shared_ptr<Impl> _impl;
 };

--- a/include/Pothos/Framework/BufferAccumulator.hpp
+++ b/include/Pothos/Framework/BufferAccumulator.hpp
@@ -87,7 +87,7 @@ private:
     Util::RingDeque<BufferChunk> _queue;
     size_t _bytesAvailable;
     bool _inPoolBuffer;
-    Pothos::BufferPool _pool;
+    BufferPool _pool;
 };
 
 } //namespace Pothos

--- a/include/Pothos/Framework/BufferPool.hpp
+++ b/include/Pothos/Framework/BufferPool.hpp
@@ -1,0 +1,48 @@
+///
+/// \file Framework/BufferPool.hpp
+///
+/// A simple buffer pool with re-usable buffers.
+///
+/// \copyright
+/// Copyright (c) 2016-2016 Josh Blum
+/// SPDX-License-Identifier: BSL-1.0
+///
+
+#pragma once
+#include <Pothos/Config.hpp>
+#include <Pothos/Framework/BufferChunk.hpp>
+#include <vector>
+
+namespace Pothos {
+
+/*!
+ * The simple buffer pool holds a collection of re-usable buffers.
+ * When the client requests a particular buffer size from the pool,
+ * the pool first looks for an existing and unused buffer
+ * that matches the requested size, or allocates a new buffer.
+ */
+class POTHOS_API BufferPool
+{
+public:
+
+    //! Construct an empty buffer pool
+    BufferPool(void);
+
+    /*!
+     * Clear all existing entries in the pool.
+     */
+    void clear(void);
+
+    /*!
+     * Get a buffer from the pool or make one if none available.
+     * \param numBytes the size of the requested buffer in bytes
+     * \return an available buffer chunk of at least numBytes size
+     */
+    const Pothos::BufferChunk &get(const size_t numBytes);
+
+private:
+    size_t _minBuffSize;
+    std::vector<Pothos::BufferChunk> _buffs;
+};
+
+} //namespace Pothos

--- a/include/Pothos/Framework/OutputPort.hpp
+++ b/include/Pothos/Framework/OutputPort.hpp
@@ -4,7 +4,7 @@
 /// This file provides an interface for a worker's output port.
 ///
 /// \copyright
-/// Copyright (c) 2014-2015 Josh Blum
+/// Copyright (c) 2014-2016 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -13,6 +13,7 @@
 #include <Pothos/Object/Object.hpp>
 #include <Pothos/Framework/DType.hpp>
 #include <Pothos/Framework/Label.hpp>
+#include <Pothos/Framework/BufferPool.hpp>
 #include <Pothos/Framework/BufferChunk.hpp>
 #include <Pothos/Framework/BufferManager.hpp>
 #include <Pothos/Util/RingDeque.hpp>
@@ -116,6 +117,17 @@ public:
     void popBuffer(const size_t numBytes);
 
     /*!
+     * Get a buffer of a specified size in elements.
+     * Some blocks may require buffers of arbitrary size
+     * for use with postBuffer() and postMessage() calls.
+     * The call will attempt to use the front buffer from
+     * this output port and will fall-back to a reusable pool.
+     * \param numElements the minimum buffer size
+     * \return a buffer chunk with at least numElements
+     */
+    BufferChunk getBuffer(const size_t numElements);
+
+    /*!
      * Post an output label to the subscribers on this port.
      * \param label the label to post
      */
@@ -215,6 +227,7 @@ private:
     std::vector<InputPort *> _subscribers;
     InputPort *_readBeforeWritePort;
     bool _bufferFromManager;
+    BufferPool _bufferPool;
 
     OutputPort(void);
     OutputPort(const OutputPort &){} // non construction-copyable

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -159,6 +159,7 @@ list(APPEND POTHOS_SOURCES
     Framework/ThreadEnvironment.cpp
     Framework/SharedBuffer.cpp
     Framework/ManagedBuffer.cpp
+    Framework/BufferPool.cpp
     Framework/BufferChunk.cpp
     Framework/BufferConvert.cpp
     Framework/BufferManager.cpp

--- a/lib/Framework/BufferAccumulator.cpp
+++ b/lib/Framework/BufferAccumulator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 Josh Blum
+// Copyright (c) 2013-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/BufferAccumulator.hpp>
@@ -53,19 +53,13 @@ private:
  **********************************************************************/
 struct Pothos::BufferAccumulator::Impl
 {
-    Impl(void):
-        inPoolBuffer(false)
-    {
-        return;
-    }
-
-    bool inPoolBuffer;
     HelperBufferPool pool;
 };
 
 Pothos::BufferAccumulator::BufferAccumulator(void):
     _queue(64/*arbitrary*/),
     _bytesAvailable(0),
+    _inPoolBuffer(false),
     _impl(new Impl())
 {
     //never let the queue become empty -- hold an empty buffer
@@ -162,7 +156,7 @@ void Pothos::BufferAccumulator::pop(const size_t numBytes)
     //and the remainder bytes are in front+1,
     //then pop the front and move into front+1.
     if (
-        _impl->inPoolBuffer and queue.size() > 1 and //pool in front
+        _inPoolBuffer and queue.size() > 1 and //pool in front
         queue.front().length <= (queue[1].address - queue[1].getBuffer().getAddress()))
     {
         queue[1].address -= queue.front().length;
@@ -192,7 +186,7 @@ void Pothos::BufferAccumulator::pop(const size_t numBytes)
     }
 
     //clear the pool buffer state when the queue size shrinks
-    if (_impl->inPoolBuffer and queueSize != queue.size()) _impl->inPoolBuffer = false;
+    if (_inPoolBuffer and queueSize != queue.size()) _inPoolBuffer = false;
 
     //pop all of the front-most consumed buffers
     while (not queue.empty() and queue.front().length == 0) queue.pop_front();
@@ -218,7 +212,7 @@ void Pothos::BufferAccumulator::require(const size_t numBytes)
     if (_bytesAvailable < numBytes and queue.size() == 1 and
         numBytes <= queue.front().getBuffer().getLength()) return;
 
-    //Actually this is ok: assert(not _impl->inPoolBuffer);
+    //Actually this is ok: assert(not _inPoolBuffer);
     //The smaller pool buffer in front will be absorbed and popped.
 
     //get a buffer that can hold the required bytes
@@ -256,7 +250,7 @@ void Pothos::BufferAccumulator::require(const size_t numBytes)
     }
 
     //finally store the new buffer to the front
-    _impl->inPoolBuffer = true;
+    _inPoolBuffer = true;
     queue.push_front(std::move(newBuffer));
 }
 

--- a/lib/Framework/BufferPool.cpp
+++ b/lib/Framework/BufferPool.cpp
@@ -3,15 +3,18 @@
 
 #include <Pothos/Framework/BufferPool.hpp>
 
+//! The default size of allocations until the client requests larger buffers
+static const size_t defaultSize = 8*1024;
+
 Pothos::BufferPool::BufferPool(void):
-    _minBuffSize(0)
+    _minBuffSize(defaultSize)
 {
     return;
 }
 
 void Pothos::BufferPool::clear(void)
 {
-    _minBuffSize = 0;
+    _minBuffSize = defaultSize;
     _buffs.clear();
 }
 

--- a/lib/Framework/BufferPool.cpp
+++ b/lib/Framework/BufferPool.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2013-2016 Josh Blum
+// SPDX-License-Identifier: BSL-1.0
+
+#include <Pothos/Framework/BufferPool.hpp>
+
+Pothos::BufferPool::BufferPool(void):
+    _minBuffSize(0)
+{
+    return;
+}
+
+void Pothos::BufferPool::clear(void)
+{
+    _minBuffSize = 0;
+    _buffs.clear();
+}
+
+const Pothos::BufferChunk &Pothos::BufferPool::get(const size_t numBytes)
+{
+    //user asked for a larger buffer size -- drop all entries
+    if (numBytes > _minBuffSize)
+    {
+        _buffs.clear();
+        _minBuffSize = numBytes;
+    }
+
+    //find the first buffer where we hold the only copy
+    for (size_t i = 0; i < _buffs.size(); i++)
+    {
+        if (_buffs[i].getBuffer().unique()) return _buffs[i];
+    }
+
+    //otherwise make a new buffer
+    _buffs.emplace_back(_minBuffSize);
+    return _buffs.back();
+}


### PR DESCRIPTION
* Resolves #61 
* Create a reusable buffer pool class used in the buffer accumulator
* Added a pool to the outputport accessible through getBuffer()