### PR TITLE
Fixed memory leak of implementation data in FileLock

### DIFF
--- a/include/Pothos/Util/FileLock.hpp
+++ b/include/Pothos/Util/FileLock.hpp
@@ -45,7 +45,7 @@ public:
 
 private:
     struct Impl;
-    Impl *_impl;
+    std::shared_ptr<Impl> _impl;
 
     FileLock(const FileLock&){}
     void operator=(const FileLock&){}


### PR DESCRIPTION
I noticed this leak when I was testing my own block